### PR TITLE
Reenable GitHub Pages telemetry

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,28 +15,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: make check
-  # TODO: Fix telemetry and reenable
-  # telemetry:
-  #   name: Telemetry
-  #   needs: checks
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: ghcr.io/doitintl/docops/devcontainer:main
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: make telemetry
-  #     - uses: crazy-max/ghaction-github-status@v2
-  #       with:
-  #         pages_threshold: major_outage
-  #     - uses: crazy-max/ghaction-github-pages@v2
-  #       if: success() && github.event_name != 'pull_request'
-  #       with:
-  #         target_branch: gh-pages
-  #         build_dir: gh-pages
-  #         keep_history: true
-  #         jekyll: false
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: make telemetry
+      - uses: crazy-max/ghaction-github-status@v2
+        with:
+          pages_threshold: major_outage
+      - uses: crazy-max/ghaction-github-pages@v2
+        if: success() && github.event_name != 'pull_request'
+        with:
+          target_branch: gh-pages
+          build_dir: gh-pages
+          keep_history: true
+          jekyll: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   notification:
     name: Notification
     needs: checks

--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,9 @@ telemetry: $(GH_PAGES_DIR)/index.html
 $(GH_PAGES_DIR)/index.html:
 	$(call print-target)
 	@ mkdir -p $(dir $@)
+	cd $(dir $@) && touch .nojekyll
+	cd $(dir $@) && touch robots.txt
+	cd $(dir $@) && printf "User-agent: *\nDisallow: /\n" > robots.txt
 	$(WWW_INDEX) $(dir $@) $@
 
 # assets.html
@@ -430,7 +433,6 @@ $(GH_PAGES_DIR)/assets.html:
 	$(call print-target)
 	@ mkdir -p $(dir $@)
 	$(GEN_ASSETS_LIST) $(GITBOOK_CMP_DIR)/$(GITBOOK_ASSETS_DIR) >$@
-	@ # TODO: Format the HTML file
 
 # vale.json
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This commit disables the placeholder generation of Vale telemetry, improves the `gh-pages` build, and reenables the telemetry step during CICD.
