### PR TITLE
Add TypeScript, catch MDX errors, fix issues 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env.local
 .env.production.local
 .env.test.local
+*.err
 *.log
 *.out
 *.tmp

--- a/website/Makefile
+++ b/website/Makefile
@@ -7,6 +7,8 @@
 # POSIX locale
 LC_ALL = C
 
+BUILD_ERRORS = build.err
+
 .DEFAULT_GOAL = help
 
 .PHONY: help
@@ -35,7 +37,11 @@ start: install
 
 .PHONY: build # Bundle the website into static files for production
 build: install
-	yarn build
+	rm -f $(BUILD_ERRORS)
+	yarn build 2>$(BUILD_ERRORS)
+	sed -i -E '/^($$|[^a-zA-Z])/d' $(BUILD_ERRORS)
+	if test -s $(BUILD_ERRORS); then cat $(BUILD_ERRORS); exit 1; fi
+	rm -f $(BUILD_ERRORS)
 
 .PHONY: serve # Serve the built website locally
 serve: install

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -99,6 +99,8 @@ One important aspect of the BigQuery Lens Dashboard is the Recommendations widge
 
 Each recommendation category comes with further details on how to act on each recommendation.
 
+import YouTubeEmbed from '@site/src/components/YouTubeEmbed';
+
 <!-- cspell: disable-next-line -->
 
 <YouTubeEmbed id="7r1WfwnBAA4" />

--- a/website/package.json
+++ b/website/package.json
@@ -34,5 +34,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@docusaurus/module-type-aliases": "^2.0.0-beta.20",
+    "@tsconfig/docusaurus": "^1.0.5",
+    "typescript": "^4.6.4"
   }
 }

--- a/website/src/components/YouTubeEmbed/index.tsx
+++ b/website/src/components/YouTubeEmbed/index.tsx
@@ -6,7 +6,7 @@ interface Props {
   id: string;
 }
 
-export default function LoomEmbed({ id = '' }: Props): JSX.Element {
+export default function YouTubeEmbed({ id = '' }: Props): JSX.Element {
   return (
     <div className={styles.youtubeEmbed}>
       <iframe

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/docusaurus/tsconfig.json"
+}

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1508,7 +1508,7 @@
     url-loader "^4.1.1"
     webpack "^5.72.0"
 
-"@docusaurus/module-type-aliases@2.0.0-beta.20":
+"@docusaurus/module-type-aliases@2.0.0-beta.20", "@docusaurus/module-type-aliases@^2.0.0-beta.20":
   version "2.0.0-beta.20"
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.20.tgz#669605a64b04226c391e0284c44743e137eb2595"
   integrity sha512-lUIXLwQEOyYwcb3iCNibPUL6O9ijvYF5xQwehGeVraTEBts/Ch8ZwELFk+XbaGHKh52PiVxuWL2CP4Gdjy5QKw==
@@ -2021,6 +2021,11 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+
+"@tsconfig/docusaurus@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-1.0.5.tgz#5298c5b0333c6263f06c3149b38ebccc9f169a4e"
+  integrity sha512-KM/TuJa9fugo67dTGx+ktIqf3fVc077J6jwHu845Hex4EQf7LABlNonP/mohDKT0cmncdtlYVHHF74xR/YpThg==
 
 "@types/body-parser@*":
   version "1.19.2"
@@ -7425,6 +7430,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@^4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"


### PR DESCRIPTION
This change modifies the `build` target to test for MDX errors and error out if any are found. I also fixed the MDX error caused by using the `YouTubeEmbed` component without importing first.

See the following for more information:

- https://github.com/facebook/docusaurus/discussions/7116

Additionally, I have added Docusaurus [TypeScript support][tsx-support].

[tsx-support]: https://docusaurus.io/docs/typescript-support