### PR TITLE
Temporarily disable the DocSearch component, plus other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ build:
 	$(call print-target)
 	@ $(MAKE) -C website $@
 
+.PHONY: serve # Serve the built website locally
+serve:
+	$(call print-target)
+	@ $(MAKE) -C website serve
+
 .PHONY: telemetry # Generate telemetry data
 telemetry:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DoiT Help
 
-_DoiT International help site and product documentation_
+_DoiT International Help Center and product documentation_
 
 [![CICD][actions-cicd-img]][actions-cicd-workflow]
 

--- a/website/src/components/Search/index.js
+++ b/website/src/components/Search/index.js
@@ -4,11 +4,15 @@ import { DocSearch } from '@docsearch/react';
 import '@docsearch/css';
 
 const Search = () => (
+  // Disabled because it causes the index page to crash
+  /*
   <DocSearch
     appId={process.env.ALGOLIA_APP_ID}
     indexName={process.env.INDEX_NAME}
     apiKey={process.env.ALGOLIA_API_KEY}
   />
+  */
+  <div />
 );
 
 export default Search;


### PR DESCRIPTION
The DocSearch component was causing the front page to crash, which is preventing me from making progress. I have disabled the component for now and will work with @erezstmn-doit to fix and reenable it.