### PR TITLE
Manually trigger production builds

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -8,8 +8,8 @@ on:
       - feature/fssa
 
 jobs:
-  check:
-    name: Check
+  run-checks:
+    name: Run checks
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/doitintl/docops/devcontainer:main
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/checkout@v2
       - run: make check
 
-  build:
-    name: Build
+  test-build:
+    name: Test build
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/doitintl/docops/devcontainer:main
@@ -26,16 +26,27 @@ jobs:
       - uses: actions/checkout@v2
       - run: make build
 
-  # TODO: Trigger Netlify deployment if check and build succeed
+  trigger-prod-build:
+    name: Trigger production build
+    needs:
+      - run-checks
+      - test-build
+    if: |
+      github.event_name != 'pull_request'
+      && github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -X POST -d {} ${{ secrets.NETLIFY_BUILD_HOOK }}
 
   # TODO: Use custom Python script to handle repository notifications (with the
   # goal being to switch to a single updatable message per commit)
 
   notification:
-    name: Notification
+    name: Send notification
     needs:
-      - check
-      - build
+      - run-checks
+      - test-build
+      - trigger-prod-build
     if: |
       always()
       && github.event_name != 'pull_request'

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,4 +1,4 @@
-name: Commit
+name: Push
 
 on:
   pull_request:

--- a/.github/workflows/weekend.yaml
+++ b/.github/workflows/weekend.yaml
@@ -1,4 +1,4 @@
-name: Cron
+name: Weekend
 
 on:
   schedule:


### PR DESCRIPTION
Netlify auto-publishing has been turned off, so commits to the main branch no longer automatically trigger a production build, allowing us to verify changes before publishing them.

To complete this change, I have added a new job to the Commit workflow that triggers a production build if and only if the preceding jobs succeed.