### PR TITLE
Add image zoom, auto-hide nav bar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -53,7 +53,7 @@ const config = {
       },
       navbar: {
         title: 'Help Center',
-        hideOnScroll: false,
+        hideOnScroll: true,
         logo: {
           alt: 'DoiT International',
           src: 'img/doit-logo-black.svg',
@@ -209,6 +209,9 @@ const config = {
         indexName: process.env.INDEX_NAME,
       },
       */
+      zoom: {
+        selector: '.markdown img',
+      },
     }),
   plugins: [
     [
@@ -221,6 +224,7 @@ const config = {
         disableInDev: true,
       }),
     ],
+    require.resolve('docusaurus-plugin-image-zoom'),
   ],
   customFields: {
     ALGOLIA_API_KEY: process.env.ALGOLIA_API_KEY,

--- a/website/package.json
+++ b/website/package.json
@@ -22,6 +22,7 @@
     "@mdx-js/react": "^1.6.22",
     "@types/react": ">= 16.8.0 < 18.0.0",
     "clsx": "^1.1.1",
+    "docusaurus-plugin-image-zoom": "^0.1.0",
     "dotenv": "^16.0.1",
     "prism-react-renderer": "^1.2.1",
     "prop-types": ">=15",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -86,6 +86,13 @@ article div div {
   margin-bottom: var(--ifm-leading);
 }
 
+/* Zoom CSS fix */
+
+.medium-zoom-overlay,
+.medium-zoom-image {
+  z-index: 9999;
+}
+
 /* Footer colors */
 
 .footer {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3814,6 +3814,13 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+docusaurus-plugin-image-zoom@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-0.1.0.tgz#7b4237bca916161330c2fe15fa80a746ebec9558"
+  integrity sha512-ylRM9fDn7kYOXBxz+Tmzm7yyv/fGtGikrOvjNhw4npQ9Z2/DENHiJFB5/hOTvfPbaXvTuYFsCyzPh4dRSxT/cg==
+  dependencies:
+    medium-zoom "^1.0.6"
+
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
@@ -5541,6 +5548,11 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+medium-zoom@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.0.6.tgz#9247f21ca9313d8bbe9420aca153a410df08d027"
+  integrity sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg==
 
 memfs@^3.1.2, memfs@^3.4.1:
   version "3.4.1"


### PR DESCRIPTION
This commit adds the [docusaurus-plugin-image-zoom][image-zoom] plugin, which makes all docs images zoomable. To complement this change, I have enabled the nav bar hide-on-scroll behavior.

A small CSS fix was required to get the zoom container to appear above the nav bar, when visible.

At the moment, when installing the plugin, `yarn` produces a warning about private workspaces. I have filed this as [issue #5][issue-5] on the upstream project.

[image-zoom]: https://github.com/gabrielcsapo/docusaurus-plugin-image-zoom
[issue-5]: https://github.com/gabrielcsapo/docusaurus-plugin-image-zoom/issues/5