### PR TITLE
Configure the initial set of spotlight features

### DIFF
--- a/gitbook/cmp/cloud-analytics/create-cloud-report/report-dimensions-groupings-and-filters.md
+++ b/gitbook/cmp/cloud-analytics/create-cloud-report/report-dimensions-groupings-and-filters.md
@@ -62,7 +62,7 @@ In the screenshot below you can see that projects are being grouped along the ve
 
 > **SKU**
 >
-> The ID of the resource used by the service. For the full list of SKUs, see the [Pricing table report](https://cloud.google.com/billing/docs/how-to/pricing-table)t
+> The ID of the resource used by the service. For the full list of SKUs, see the [Pricing table report](https://cloud.google.com/billing/docs/how-to/pricing-table).
 
 > **Unit**
 >

--- a/website/docs/cloud-analytics/create-cloud-report/report-dimensions-groupings-and-filters.mdx
+++ b/website/docs/cloud-analytics/create-cloud-report/report-dimensions-groupings-and-filters.mdx
@@ -66,7 +66,7 @@ In the screenshot below you can see that projects are being grouped along the ve
 
 > **SKU**
 >
-> The ID of the resource used by the service. For the full list of SKUs, see the [Pricing table report](https://cloud.google.com/billing/docs/how-to/pricing-table)t
+> The ID of the resource used by the service. For the full list of SKUs, see the [Pricing table report](https://cloud.google.com/billing/docs/how-to/pricing-table).
 
 > **Unit**
 >

--- a/website/docs/cmp.mdx
+++ b/website/docs/cmp.mdx
@@ -65,21 +65,21 @@ You may have various components of your application(s) spread across different p
 
 When you create an instance in Google Cloud and it is under-utilized, you are paying more than you should as a result of idle resources.
 
-With Instance Rightsizing for Google Cloud, you will:
+With instance [Rightsizing for Google Cloud](dashboards/rightsizing-for-google-cloud.mdx), you will:
 
 - Get notified of idle resources across _all_ projects, and potential savings from rightsizing.
-- [Identify and delete and/or modify idle VMs](dashboards/rightsizing-for-google-cloud.mdx) in two clicks.
+- Identify and delete and/or modify idle VMs in two clicks.
 - Never pay for underutilized Google Compute instances again.
 
 <LoomEmbed id="cecfc1a7f3d84240a5be922e27c0ac56" />
 
 ### Flexsave
 
-Purchasing compute commitments &mdash; Reserved Instances (RIs) or Savings Plans (SPs) for AWS; Committed Use Discounts (CUDs) for Google Cloud &mdash; is a great way for you to reduce your compute costs for stable, predictable workloads.
+Purchasing compute commitments &mdash; Reserved Instances (RIs) and Savings Plans (SPs) for AWS or Committed Use Discounts (CUDs) for Google Cloud &mdash; is a great way for you to reduce your compute costs for stable, predictable workloads.
 
 However, getting compute commitments _just right_ and then managing them is an extremely manual, never-ending process. Flexsave automates this for you while maximizing your compute discounts.
 
-Flexsave works by analyzing your workloads, seeing which ones aren't covered by compute commitments like CUDs, RIs, or Savings Plans. Then, with the click of a button, it assigns reserved compute resources from DoiT's own wholesale inventory to optimally cover them, continuously monitoring for any changes in needs.
+[Flexsave](flexsave/overview.mdx) works by analyzing your workloads, seeing which ones aren't covered by compute commitments like CUDs, RIs, or Savings Plans. Then, with the click of a button, it assigns reserved compute resources from DoiT's own wholesale inventory to optimally cover them, continuously monitoring for any changes in needs.
 
 See how it works in the video below:
 

--- a/website/src/components/ContactSupport/index.js
+++ b/website/src/components/ContactSupport/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styles from './styles.module.css';
+import Link from '@docusaurus/Link';
 
 const ContactSupport = () => {
   return (
@@ -11,16 +12,14 @@ const ContactSupport = () => {
             <p>
               Our technical support team and cloud reliability engineers are
               standing by,{' '}
-              <a href="https://doit-intl.com/stats/" target="_blank">
-                24 hours a day
-              </a>
+              <Link to="https://doit-intl.com/stats/">24 hours a day</Link>
             </p>
             <p>
-              <a href="https://app.doit-intl.com/support" target="_blank">
+              <Link to="https://app.doit-intl.com/support">
                 <button className={styles.contact_button}>
                   Open a ticket
                 </button>
-              </a>
+              </Link>
             </p>
           </div>
         </div>

--- a/website/src/components/ContactSupport/styles.module.css
+++ b/website/src/components/ContactSupport/styles.module.css
@@ -26,7 +26,7 @@
 
 .contact_button {
   cursor: pointer;
-  background-color: var(--ifm-color-primary-light);
+  background-color: var(--ifm-color-primary-lighter);
   color: var(--ifm-color-primary-contrast-background);
   box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2),
     0px 2px 2px rgba(0, 0, 0, 0.14), 0px 1px 5px rgba(0, 0, 0, 0.12);
@@ -40,5 +40,5 @@
 }
 
 .contact_button:hover {
-  background-color: var(--ifm-color-primary-dark);
+  background-color: var(--ifm-color-primary);
 }

--- a/website/src/components/GettingStarted/index.js
+++ b/website/src/components/GettingStarted/index.js
@@ -10,11 +10,13 @@ const cards = [
     title: 'Cloud Management Platform',
     image: cmpIcon,
     href: '/docs/cmp',
+    target: '',
   },
   {
     title: 'Developer Hub',
     image: devHubIcon,
     href: 'https://developer.doit-intl.com/',
+    target: '_blank',
   },
 ];
 

--- a/website/src/components/IconCard/index.js
+++ b/website/src/components/IconCard/index.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import ThemedImage from '@theme/ThemedImage';
+import Link from '@docusaurus/Link';
 
 import styles from './styles.module.css';
 
 const IconCard = ({ card }) => (
   <div className={`col ${styles.icon_card}`}>
-    <a href={card.href} className={styles.icon_card_inner}>
+    <Link to={card.href} className={styles.icon_card_inner}>
       <card.image />
       <p className={styles.icon_card_title}>{card.title}</p>
-    </a>
+    </Link>
   </div>
 );
 

--- a/website/src/components/LinkList/index.js
+++ b/website/src/components/LinkList/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import Link from '@docusaurus/Link';
 
 import styles from './styles.module.css';
 
 const LinkList = ({ list }) => {
   const linkNodes = list.links.map((link, i) => (
     <li key={i}>
-      <a href={link.href}>{link.text}</a>
+      <Link to={link.href}>{link.text}</Link>
     </li>
   ));
   return (

--- a/website/src/components/SpotlightFeatures/index.js
+++ b/website/src/components/SpotlightFeatures/index.js
@@ -1,36 +1,60 @@
 import React from 'react';
-import clsx from 'clsx';
 import styles from './styles.module.css';
+import Link from '@docusaurus/Link';
 
-import logoBlackUrl from '../../../static/images/doit-logo-black.png';
-import logoWhiteUrl from '../../../static/images/doit-logo-white.png';
-
-import ThemedImage from '@theme/ThemedImage';
-
-const featureList = [
+const featureListRow1 = [
   {
-    title: 'Under construction',
-    description: 'This is a preview of the DoiT International Help Center.',
-    link: {
-      text: 'This is a link',
-      href: '/test',
-    },
+    title: 'Cloud analytics',
+    description:
+      'Build your own cloud analytics reports and share them with your team. \
+      Group resources and their associated costs with custom attributions, \
+      detect and analyze trends, forecast your cloud spend, and manage your \
+      budgets.',
+    link: '/docs/cmp#cloud-analytics',
   },
   {
-    title: 'Under construction',
-    description: 'This is a preview of the DoiT International Help Center.',
-    link: {
-      text: 'This is a link',
-      href: '/test',
-    },
+    title: 'Rightsizing for Google Cloud',
+    description:
+      'Rightsizing for Google Cloud monitors resources across all of your \
+      projects and makes automatic cost-savings recommendations. Identify and \
+      deal with idle VMs in two clicks. Never pay for underutilized instances \
+      again.',
+    link: '/docs/dashboards/rightsizing-for-google-cloud',
   },
   {
-    title: 'Under construction',
-    description: 'This is a preview of the DoiT International Help Center.',
-    link: {
-      text: 'This is a link',
-      href: '/test',
-    },
+    title: 'Flexsave',
+    description:
+      'Flexsave is your cloud co-pilot, dynamically maximizing your \
+      cloud-compute discounts for AWS and Google Cloud without any of the \
+      risks or limitations of long-term use commitments.',
+    link: '/docs/flexsave/overview',
+  },
+];
+
+const featureListRow2 = [
+  {
+    title: 'BigQuery Lens',
+    description:
+      'BigQuery Lens is your Swiss Army knife for highlighting inefficiencies \
+      in your BigQuery usage. Zero-configuration analytics and smart \
+      recommendations for your database administrators.',
+    link: 'docs/dashboards/bigquery-lens',
+  },
+  {
+    title: 'AWS Lens',
+    description:
+      'AWS Lens provides full visibility into your cloud finances with a \
+      configurable analytics dashboard that allows you to monitor operations \
+      and optimize costs.',
+    link: '/docs/dashboards/aws-lens',
+  },
+  {
+    title: 'Spot scaling',
+    description:
+      "Spot Scaling proactively monitors your AWS Auto-Scaling Groups (ASGs), \
+      and uses sophisticated machine learning to replace some or all of an \
+      ASG's on-demand EC2 instances with Spot Instances.",
+    link: '/docs/spot-scaling/overview',
   },
 ];
 
@@ -39,7 +63,7 @@ const Feature = ({ title, description, link }) => (
     <h2>{title}</h2>
     <p>{description}</p>
     <p>
-      <a href={link.href}>{link.text}</a>
+      <Link to={link}>Learn more&hellip;</Link>
     </p>
   </div>
 );
@@ -49,7 +73,12 @@ const SpotlightFeatures = () => (
     <div className="container">
       <h1>Spotlight features</h1>
       <div className="row">
-        {featureList.map((props, idx) => (
+        {featureListRow1.map((props, idx) => (
+          <Feature key={idx} {...props} />
+        ))}
+      </div>
+      <div className="row">
+        {featureListRow2.map((props, idx) => (
           <Feature key={idx} {...props} />
         ))}
       </div>


### PR DESCRIPTION
Create the initial set of spotlight features

Spotlight features:

- Cloud analytics
- Rightsizing for Google Cloud
- Flexsave
- BigQuery Lens
- AWS Lens
- Spot scaling

I assembled this initial list of spotlight features to mirror the existing docs as much as possible by:

- Cherry-picking prominent headings from the CMP docs front page and navigation sidebar.

- Ordering them approximately by their order of appearance in the aforementioned places.

The CMP docs front page and navigation sidebar are in need of some major improvements, but that is out of scope for now.

To make the transition away from GitBook as smooth as possible, we want to launch a Docusaurus website that closely mirrors the existing CMP docs. After launch, we can restructure and rework what we have as we develop out the help center.

Over time, we can use analytics (e.g., Mixpanel) and internal feedback to improve (and maybe even automate) our selections for the spotlight features.