### PR TITLE
Overhaul the CSS and front page implementation

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -158,7 +158,7 @@ const config = {
             ],
           },
           {
-            title: 'Additional information',
+            title: 'Company',
             items: [
               {
                 label: 'Vendor information',

--- a/website/src/components/ContactSupport/index.js
+++ b/website/src/components/ContactSupport/index.js
@@ -8,19 +8,19 @@ const ContactSupport = () => {
       <div className="container">
         <div className="row">
           <div className={`col ${styles.contact_support_cta}`}>
-            <h1>Get in touch</h1>
+            <h2>Talk to an expert</h2>
             <p>
               Our technical support team and cloud reliability engineers are
-              standing by,{' '}
-              <Link to="https://doit-intl.com/stats/">24 hours a day</Link>
+              available 24 hours a day.
+              <wbr /> We publish our{' '}
+              <Link to="https://doit-intl.com/stats/">live stats</Link> so
+              you can see how we're doing.
             </p>
-            <p>
-              <Link to="https://app.doit-intl.com/support">
-                <button className={styles.contact_button}>
-                  Open a ticket
-                </button>
-              </Link>
-            </p>
+            <Link to="https://app.doit-intl.com/support">
+              <button className="clean-btn button button--primary">
+                OPEN A TICKET
+              </button>
+            </Link>
           </div>
         </div>
       </div>

--- a/website/src/components/ContactSupport/styles.module.css
+++ b/website/src/components/ContactSupport/styles.module.css
@@ -7,38 +7,11 @@
   margin: auto !important;
   padding-top: 0 !important;
   padding-bottom: 0 !important;
+  max-width: 40em;
 }
 
-@media screen and (max-width: 996px) {
-  .contact_support_cta {
-    max-width: 30em;
-  }
-}
-
-.contact_support_cta h1 {
-  font-style: normal;
-  font-weight: 500;
-  font-size: 36px;
-  line-height: 44px;
-  letter-spacing: 0.25px;
+.contact_support_cta h2 {
+  margin-bottom: var(--ifm-spacing-vertical) !important;
+  font-weight: var(--ifm-font-weight-normal);
   text-align: center;
-}
-
-.contact_button {
-  cursor: pointer;
-  background-color: var(--ifm-color-primary-lighter);
-  color: var(--ifm-color-primary-contrast-background);
-  box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2),
-    0px 2px 2px rgba(0, 0, 0, 0.14), 0px 1px 5px rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
-  border-width: 0;
-  width: 139px;
-  height: 36px;
-  font-weight: var(--ifm-font-weight-semibold);
-  font-size: 14px;
-  text-transform: uppercase;
-}
-
-.contact_button:hover {
-  background-color: var(--ifm-color-primary);
 }

--- a/website/src/components/GettingStarted/index.js
+++ b/website/src/components/GettingStarted/index.js
@@ -23,7 +23,7 @@ const cards = [
 const GettingStarted = () => (
   <section className={styles.getting_started}>
     <div className="container">
-      <h1>Getting Started</h1>
+      <h2>Getting Started</h2>
       <div className="row">
         {cards.map((card, i) => (
           <IconCard key={i} card={card} />

--- a/website/src/components/GettingStarted/styles.module.css
+++ b/website/src/components/GettingStarted/styles.module.css
@@ -1,10 +1,3 @@
 .getting_started {
   background: #ffffff;
-  padding-bottom: 1em;
-}
-
-@media screen and (min-width: 996px) {
-  .getting_started {
-    padding: 0;
-  }
 }

--- a/website/src/components/Header/styles.module.css
+++ b/website/src/components/Header/styles.module.css
@@ -1,5 +1,5 @@
 .hero_banner {
-  padding: 4rem 0;
+  padding: var(--ifm-spacing-vertical-4x) 0;
   display: flex;
   flex-direction: column;
   text-align: center;

--- a/website/src/components/IconCard/styles.module.css
+++ b/website/src/components/IconCard/styles.module.css
@@ -1,5 +1,6 @@
 .icon_card {
-  padding-left: 1rem !important;
+  margin: 0 !important;
+  padding: var(--ifm-spacing-vertical) !important;
 }
 
 .icon_card_inner {
@@ -10,7 +11,6 @@
   justify-content: center;
   width: auto;
   margin: auto;
-  max-width: 750px;
   box-shadow: 4px 32px 13px rgba(152, 165, 189, 0.01),
     2px 18px 11px rgba(152, 165, 189, 0.05),
     1px 8px 8px rgba(152, 165, 189, 0.09),
@@ -24,16 +24,11 @@
   text-decoration: none;
 }
 
-.icon_card_inner svg {
-  margin-top: 1rem;
-}
-
 .icon_card_inner:hover svg {
   filter: saturate(180%);
 }
 
 .icon_card_title {
-  margin: 0 0 1rem 0;
   color: var(--ifm-font-color-base);
   font-weight: var(--ifm-font-weight-semibold);
 }
@@ -42,16 +37,22 @@
   color: var(--ifm-color-primary);
 }
 
-@media screen and (min-width: 996px) {
-  .icon_card {
-    padding-left: 2rem !important;
-  }
-
+@media screen and (max-width: 995px) {
   .icon_card_inner svg {
-    margin-top: 2rem;
+    margin-top: var(--ifm-spacing-vertical);
   }
 
   .icon_card_title {
-    margin: 0 0 2rem 0;
+    margin-bottom: var(--ifm-spacing-vertical);
+  }
+}
+
+@media screen and (min-width: 996px) {
+  .icon_card_inner svg {
+    margin-top: var(--ifm-spacing-vertical-2x);
+  }
+
+  .icon_card_title {
+    margin-bottom: var(--ifm-spacing-vertical-2x);
   }
 }

--- a/website/src/components/LearnMore/index.js
+++ b/website/src/components/LearnMore/index.js
@@ -46,7 +46,7 @@ const LearnMore = () => {
   return (
     <section className={styles.learn_more}>
       <div className="container">
-        <h1>Learn more</h1>
+        <h2>Learn more</h2>
         <div className="row">
           {lists.map((list, i) => (
             <LinkList key={i} list={list}></LinkList>

--- a/website/src/components/SpotlightFeatures/index.js
+++ b/website/src/components/SpotlightFeatures/index.js
@@ -60,7 +60,7 @@ const featureListRow2 = [
 
 const Feature = ({ title, description, link }) => (
   <div className={`col ${styles.feature}`}>
-    <h2>{title}</h2>
+    <h3>{title}</h3>
     <p>{description}</p>
     <p>
       <Link to={link}>Learn more&hellip;</Link>
@@ -71,7 +71,7 @@ const Feature = ({ title, description, link }) => (
 const SpotlightFeatures = () => (
   <section className={styles.spotlight_features}>
     <div className="container">
-      <h1>Spotlight features</h1>
+      <h2>Spotlight features</h2>
       <div className="row">
         {featureListRow1.map((props, idx) => (
           <Feature key={idx} {...props} />

--- a/website/src/components/SpotlightFeatures/styles.module.css
+++ b/website/src/components/SpotlightFeatures/styles.module.css
@@ -7,10 +7,6 @@
   padding-left: 0;
 }
 
-.feature h2 {
-  white-space: nowrap;
-}
-
 .feature p:last-child {
   margin-bottom: 0;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -61,24 +61,33 @@
 
 /* Customizations for the front page grid */
 
+:root {
+  --ifm-spacing-vertical-2x: calc(var(--ifm-spacing-vertical) * 2);
+  --ifm-spacing-vertical-4x: calc(var(--ifm-spacing-vertical) * 4);
+}
+
 #front-page .container,
 .footer .container {
+  padding: var(--ifm-spacing-vertical-2x) 0;
   margin: 0 auto;
-  padding: 2rem 2rem;
+  transition: all var(--ifm-transition-fast)
+    var(--ifm-transition-timing-default);
+}
+
+#front-page .container h2 {
+  margin-bottom: var(--ifm-spacing-vertical-2x);
 }
 
 #front-page .row,
 .footer .row {
-  padding: 0;
   margin: 0;
   display: flex;
-  flex-direction: column;
 }
 
 #front-page .col,
 .footer .col {
   margin: 0;
-  padding: 1rem 1rem 1rem 0;
+  padding: 0;
   flex-grow: 1;
 }
 
@@ -87,47 +96,83 @@
   margin: 0;
 }
 
-.footer__col {
-  padding-top: 0 !important;
-}
-
-.footer__items {
-  margin-bottom: var(--ifm-heading-margin-bottom);
-}
-
 .footer__title,
 .footer__item {
   white-space: nowrap;
 }
 
-@media screen and (min-width: 996px) {
+.footer__bottom > div {
+  margin: 0 !important;
+}
+
+.footer__bottom > div a {
+  display: block;
+  height: 100px;
+}
+
+.footer__bottom img {
+  margin: 0;
+}
+
+@media screen and (max-width: 995px) {
   #front-page .container,
   .footer .container {
-    padding: 2rem 4rem;
+    width: 90vw;
+    max-width: 750px;
   }
 
+  .footer .container {
+    overflow: hidden;
+  }
+
+  #front-page .row,
+  .footer .row {
+    flex-direction: column;
+  }
+
+  #front-page .row + .row,
+  .footer .row + .row {
+    margin-top: var(--ifm-spacing-vertical-2x);
+  }
+
+  #front-page .col + .col,
+  .footer .col + .col {
+    margin-top: var(--ifm-spacing-vertical-2x);
+  }
+
+  .footer .row {
+    float: left;
+  }
+
+  .footer__items {
+    margin-bottom: var(--ifm-heading-margin-bottom);
+  }
+
+  .footer__bottom {
+    float: right;
+    margin: 0 !important;
+  }
+}
+
+@media screen and (min-width: 996px) {
   #front-page .row,
   .footer .row {
     flex-direction: row;
   }
 
-  #front-page .col,
-  .footer .col {
-    padding: 2rem 2rem 2rem 0;
-  }
-}
-
-@media screen and (max-width: 995px) {
-  .footer .row {
-    float: left;
+  #front-page .row + .row,
+  .footer .row + div {
+    margin-top: var(--ifm-spacing-vertical-4x);
   }
 
-  .footer__bottom {
-    float: right;
+  #front-page .col + .col,
+  .footer .col + .col {
+    margin-left: var(--ifm-spacing-vertical-4x);
   }
 
-  .footer__bottom img {
-    margin: 0;
+  #front-page .container,
+  .footer .container {
+    padding: var(--ifm-spacing-vertical-2x) var(--ifm-spacing-vertical-4x);
   }
 }
 
@@ -151,8 +196,8 @@
 /* DocSearch */
 
 :root {
-  --docsearch-primary-color: var(--ifm-color-primary);
-  --docsearch-modal-width: var(90vw);
+  --docsearch-primary-color: var(--ifm-color-primary) !important;
+  --docsearch-modal-width: 90vw;
 }
 
 .DocSearch-Modal {
@@ -192,4 +237,15 @@
 .DocSearch-Button:focus,
 .DocSearch-Button:hover {
   color: #969faf !important;
+}
+
+/* We have a paid account and run the crawler ourselves, so we are not required
+to display the Algolia logo */
+
+.DocSearch-Footer {
+  flex-direction: row !important;
+}
+
+.DocSearch-Logo {
+  display: none;
 }


### PR DESCRIPTION
Specifically:

- Improved the how the front page content adapts and responds to changing viewport widths. Additionally, layout changes are now animated as you resize your browser window.

- Restructured the front page headings into a well-ordered hierarchy. As a result, the headings appear a little smaller now.

- Improved our integration with and use of the [Infirma][infirma] styling framework. For example, I have reworked our front page layout so that margins, paddings, etc., are derived from Infirma constants.

- In general, I am adapting the design of the front page (e.g., the use of proportions) so that it better fits in with the overall design of the site.

- Deleted some custom styles (e.g., for the _OPEN A TICKET_ button) in favor of classes that Docusaurus already provides.

- Refactored most of the component-specific styling out of the React components and into a more generalized set of rules in the `custom.css` file.

- Refactored all viewport-dependant rules into explicit media queries.

- Improved the DocSearch theming and removed the Algolia logo.

  We have a paid account and run the crawler ourselves, so we are not required to display the Algolia logo. See [Styling DocSearch: Attribution][attribution].

[infirma]: https://infima.dev/
[attribution]: https://docsearch.algolia.com/docs/legacy/styling#attribution
