### PR TITLE
Remove the videos from the CMP front page

### DIFF
--- a/website/docs/cmp.mdx
+++ b/website/docs/cmp.mdx
@@ -47,11 +47,13 @@ Cloud Analytics reports give you instant visibility into your Google Cloud and A
 - [Forecast your cloud spend](cloud-analytics/forecasting.mdx) across all time ranges and any cloud services
 - Cross-check your SUD/CUD credits with by-the-hour reporting.
 
+<!--
 <video
   type="loom"
   id="3bb89b9c624a4a52a2ecfbb61a56b4b8"
   thumb="-full-1605722125651.jpg"
 />
+-->
 
 ### Cost attributions
 
@@ -59,11 +61,13 @@ Attributions are a flexible way to group resources and their associated costs, h
 
 You may have various components of your application(s) spread across different projects, using different services. Attributions allow you to combine everything into something coherent.
 
+<!--
 <video
   type="loom"
   id="8d36dbd796c84d51a26b3f836226c883"
   thumb="-full-1600265350454.jpg"
 />
+-->
 
 ## Cloud cost optimization
 
@@ -77,11 +81,13 @@ With instance [Rightsizing for Google Cloud](dashboards/rightsizing-for-google-c
 - Identify and delete and/or modify idle VMs in two clicks.
 - Never pay for underutilized Google Compute instances again.
 
+<!--
 <video
   type="loom"
   id="cecfc1a7f3d84240a5be922e27c0ac56"
   thumb="-full-1602767610725.jpg"
 />
+-->
 
 ### Flexsave
 
@@ -89,8 +95,9 @@ Purchasing compute commitments &mdash; Reserved Instances (RIs) and Savings Plan
 
 However, getting compute commitments _just right_ and then managing them is an extremely manual, never-ending process. Flexsave automates this for you while maximizing your compute discounts.
 
-[Flexsave](flexsave/overview.mdx) works by analyzing your workloads, seeing which ones aren't covered by compute commitments like CUDs, RIs, or Savings Plans. Then, with the click of a button, it assigns reserved compute resources from DoiT's own wholesale inventory to optimally cover them, continuously monitoring for any changes in needs.
+[Flexsave](flexsave/overview.mdx) analyzes your AWS or Google Cloud workloads and assesses where commitment-based discount coverage could be improved. It then automatically addresses that coverage gap, and continuously works to ensure that it's minimized.
 
+<!--
 See how it works in the video below:
 
 <video
@@ -98,6 +105,7 @@ See how it works in the video below:
   id="b3a232a312c24735aead19d02df4c50f"
   thumb="-00001.gif"
 />
+-->
 
 ### BigQuery Lens
 
@@ -107,15 +115,16 @@ As a result, we created the [BigQuery Lens Dashboard](dashboards/bigquery-lens.m
 
 It analyzes your team's BigQuery behavior, aggregate information, and display the most important statistics for you. Unlike alternative solutions and methods, BigQuery Lens Dashboard brings important information TO you, without you having to configure anything.
 
-Below you will see the widgets of the dashboard that provide you with insights into your organization's BigQuery usage statistics.
+Dashboard widgets provide you with insights into your organization's BigQuery usage statistics.
 
 One important aspect of the BigQuery Lens Dashboard is the Recommendations widget, which offers smart recommendations around the nature of how your datasets, tables, and queries are structured.
 
 Each recommendation category comes with further details on how to act on each recommendation.
 
-<!-- cspell: disable-next-line -->
-
+<!--
+cspell: disable-next-line
 <video type="youtube" id="7r1WfwnBAA4" />
+-->
 
 ## Cloud enablement
 
@@ -135,11 +144,13 @@ First, [create a sandbox policy](cloud-sandbox-management/configuring-a-policy-f
 
 Once a policy is created, developers are free to [create cloud sandbox environments](cloud-sandbox-management/create-gcp-sandbox-accounts.mdx) themselves. No more submitting tickets just to get a new environment provisioned by an SRE. Finally, when sandboxes are up and running, you can monitor them all from a central hub.
 
+<!--
 <video
   type="loom"
   id="2e2adffc48464c0189b87e4750e7b7d3"
   thumb="-full-1602768114753.jpg"
 />
+-->
 
 ### Cloud quota monitoring
 
@@ -166,9 +177,10 @@ Available to DoiT customers right from the CMP, it also offers:
 - Fine-tune alerts by training them with your direct feedback.
 - Real-time analysis of workload activity
 
-<!-- cspell: disable-next-line -->
-
+<!--
+cspell: disable-next-line
 <video type="youtube" id="h6V7XfhsdmY" />
+-->
 
 ### Cloud support and advisory
 
@@ -181,17 +193,21 @@ Within the CMP you can:
 - [Share](services/consulting-support/ticket-sharing.mdx) support requests with others
 - Get access to exclusive [training](services/training.mdx), [professional services](services/proserv.mdx), and [perks](services/perks.mdx)
 
+<!--
 <video
   type="loom"
   id="ec2e0bca53fc46ef80061dd96be2f1a0"
   thumb="-00001.gif"
 />
+-->
 
+<!--
 <video
   type="loom"
   id="9ff183270cb84e32817818589a80d37e"
   thumb="-full-1602767998407.jpg"
 />
+-->
 
 ## Cloud governance
 


### PR DESCRIPTION
Nobody watches these and they clutter up and slow down the page.