### PR TITLE
Correct the response time of general guidance tickets

### DIFF
--- a/website/docs/services/consulting-support/index.mdx
+++ b/website/docs/services/consulting-support/index.mdx
@@ -59,9 +59,9 @@ After selecting _NEW REQUEST_, the CMP will take you through the steps of creati
 
 2. Select the severity of your request. Each severity level corresponds with a target response time:
 
-   - General Guidance &mdash; Four hours
-   - System Impaired &mdash; Two hours
-   - Production System Impaired &mdash; One hour
+   - General Guidance &mdash; 12 hours
+   - System Impaired &mdash; 2 hours
+   - Production System Impaired &mdash; 1 hour
    - Production System Down &mdash; 30 minutes
 
 3. Write a descriptive subject, add any additional CCs to the ticket, and provide a complete description of your request.


### PR DESCRIPTION
- Change the response time of general guidance tickets to 12 hours
- Change the other items to use numerals, following the MS Style Guide that "If one item requires a numeral, use numerals for all the other items of that type."