### PR TITLE
Correct June 2022 rates

### DIFF
--- a/website/docs/vendor-information/exchange-rates.mdx
+++ b/website/docs/vendor-information/exchange-rates.mdx
@@ -9,11 +9,22 @@ When DoiT International charges in local currency, we convert prices pursuant to
 
 :::note
 
-We will not notify you for increases in non-USD prices that are due to currency conversion fluctuations.
+We will _not_ notify you for increases in non-USD prices that are due to currency conversion fluctuations.
 
 :::
 
-## 2021 Historical Rates
+## 2022 rates
+
+| Month         | EUR     | GBP      | CAD      | AUD      |
+| ------------- | ------- | -------- | -------- | -------- |
+| January 2022  | 0.89051 | 0.74373  | 1.27155  | 1.414827 |
+| February 2022 | 0.89162 | 0.74505  | 1.266715 | 1.377411 |
+| March 2022    | 0.90318 | 0.76066  | 1.249995 | 1.33483  |
+| April 2022    | 0.94835 | 0.795324 | 1.284325 | 1.415049 |
+| May 2022      | 0.93164 | 0.79312  | 1.263975 | 1.39232  |
+| June 2022     | 0.95444 | 0.822355 | 1.28744  | 1.449811 |
+
+## 2021 historical rates
 
 | Month          | EUR      | GBP      | CAD      | AUD      |
 | -------------- | -------- | -------- | -------- | -------- |
@@ -29,9 +40,3 @@ We will not notify you for increases in non-USD prices that are due to currency 
 | October 2021   | 0.865195 | 0.730845 | 1.238315 | 1.33041  |
 | November 2021  | 0.882505 | 0.752058 | 1.277695 | 1.403312 |
 | December 2021  | 0.879395 | 0.739649 | 1.263915 | 1.3758   |
-| January 2022   | 0.89051  | 0.74373  | 1.27155  | 1.414827 |
-| February 2022  | 0.89162  | 0.74505  | 1.266715 | 1.377411 |
-| March 2022     | 0.90318  | 0.76066  | 1.249995 | 1.33483  |
-| April 2022     | 0.94835  | 0.795324 | 1.284325 | 1.415049 |
-| May 2022       | 0.93164  | 0.79312  | 1.263975 | 1.39232  |
-| June 2022      | 0.95561  | 0.823839 | 1.29095  | 1.454006 |


### PR DESCRIPTION
- Correct June 2022 rates
- Separate tables by year