### PR TITLE
Add `--dry-run` opiion to `prettier` check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,5 +5,3 @@
 *.py
 sphinx/cmp/docs
 build
-# TODO: Remove this (only needed for one temporary commit)
-website/src/theme/*/*.js

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,8 @@ check: ec
 lintspaces:
 check: lintspaces
 
-prettier:
-check: prettier
+prettier-dry:
+check: prettier-dry
 
 yamlcheck:
 check: yamllint

--- a/bin/prettier.sh
+++ b/bin/prettier.sh
@@ -3,7 +3,7 @@
 # Wrap the `prettier` command to provide configuration
 # =============================================================================
 
-# Usage: ./bin/prettier.sh
+# Usage: ./bin/prettier.sh [-d|--dry-run]
 
 # https://github.com/prettier/prettier
 
@@ -15,9 +15,28 @@ export LC_ALL
 RED='\x1b[1;31m'
 RESET='\x1b[0m'
 
-tmp_errors="$(mktemp)"
-if ! prettier --check --ignore-unknown . >"${tmp_errors}" 2>&1; then
-    sed -E "s,^(.*),${RED}\1${RESET}," <"${tmp_errors}"
-    rm "${tmp_errors}"
-    exit 1
+dry_run=0
+for arg in "$@"; do
+    case "${arg}" in
+    -d | --dry-run)
+        dry_run=1
+        shift
+        ;;
+    -*)
+        echo "ERROR: Unknown option: ${arg}"
+        exit 1
+        ;;
+    *) ;;
+    esac
+done
+
+if test "${dry_run}" = 1; then
+    tmp_errors="$(mktemp)"
+    if ! prettier --write --ignore-unknown . >"${tmp_errors}" 2>&1; then
+        sed -E "s,^(.*),${RED}\1${RESET}," <"${tmp_errors}"
+        rm "${tmp_errors}"
+        exit 1
+    fi
+else
+    prettier --write --ignore-unknown .
 fi

--- a/website/src/theme/Admonition/index.js
+++ b/website/src/theme/Admonition/index.js
@@ -69,7 +69,7 @@ const AdmonitionConfigs = {
   seealso: {
     infimaClassName: 'secondary',
     iconComponent: NoteIcon,
-    label: 'see also'
+    label: 'see also',
   },
   tip: {
     infimaClassName: 'success',
@@ -151,7 +151,9 @@ function extractMDXAdmonitionTitle(children) {
   };
 }
 function processAdmonitionProps(props) {
-  const { mdxAdmonitionTitle, rest } = extractMDXAdmonitionTitle(props.children);
+  const { mdxAdmonitionTitle, rest } = extractMDXAdmonitionTitle(
+    props.children,
+  );
   return {
     ...props,
     title: props.title ?? mdxAdmonitionTitle,
@@ -159,7 +161,12 @@ function processAdmonitionProps(props) {
   };
 }
 export default function Admonition(props) {
-  const { children, type, title, icon: iconProp } = processAdmonitionProps(props);
+  const {
+    children,
+    type,
+    title,
+    icon: iconProp,
+  } = processAdmonitionProps(props);
   const typeConfig = getAdmonitionConfig(type);
   const titleLabel = title ?? typeConfig.label;
   const { iconComponent: IconComponent } = typeConfig;

--- a/website/src/theme/MDXComponents/Details.js
+++ b/website/src/theme/MDXComponents/Details.js
@@ -5,7 +5,8 @@ export default function MDXDetails(props) {
   // Split summary item from the rest to pass it as a separate prop to the
   // Details theme component
   const summary = items.find(
-    (item) => React.isValidElement(item) && item.props?.mdxType === 'summary',
+    (item) =>
+      React.isValidElement(item) && item.props?.mdxType === 'summary',
   );
   const children = <>{items.filter((item) => item !== summary)}</>;
   return (

--- a/website/src/theme/MDXComponents/Pre.js
+++ b/website/src/theme/MDXComponents/Pre.js
@@ -5,7 +5,7 @@ export default function MDXPre(props) {
     <CodeBlock
       // If this pre is created by a ``` fenced codeblock, unwrap the children
       {...(isValidElement(props.children) &&
-        props.children.props?.originalType === 'code'
+      props.children.props?.originalType === 'code'
         ? props.children.props
         : { ...props })}
     />


### PR DESCRIPTION
Previously, when you run `make check`, it would run:

```
make prettier
./bin/prettier.sh
```

A common problem with Prettier is getting your text editor and the command line tool to agree on how files should be formatted. To fix this, I have added the ability to update files in place and added the `--dry-run` option for checks that should not modify files.

Now, `make check` will run:

```
make prettier-dry
./bin/prettier.sh --dry-run
```

If you're experiencing problems trying to format the files correctly to Prettier's liking, you can now run:

```
make prettier
./bin/prettier.sh
.cspell.json 47ms
.devcontainer/devcontainer.json 4ms
.docops/algolia/template.json 8ms
.github/dependabot.yml 29ms
.github/mergify.yml 8ms
.github/workflows/codeql.yml 15ms
.github/workflows/cron.yaml 33ms
.github/workflows/deployment.yaml 22ms
.github/workflows/integration.yaml 23ms
.github/workflows/review.yaml 27ms
[...]
```

As you can see above, Prettier is now going through each file and making the necessary changes.
